### PR TITLE
Generate studio monthly calendar data

### DIFF
--- a/app/Http/Controllers/Api/V1/SpotBooking/SpotBookingController.php
+++ b/app/Http/Controllers/Api/V1/SpotBooking/SpotBookingController.php
@@ -171,11 +171,12 @@ class SpotBookingController extends BaseController
                 $date = sprintf('%04d-%02d-%02d', $year, $month, $day);
                 $dayName = strtolower(Carbon::parse($date)->format('l'));
 
-                $isAvailable = $weeklyAvailability[$dayName] ?? true;
+                $isAvailable = (bool) ($weeklyAvailability[$dayName] ?? true);
                 $reason = $isAvailable ? 'Working day' : 'Holiday';
 
+                // Override weekly availability if studio has an explicit unavailable date
                 if (isset($unavailableDates[$date])) {
-                    $studioAvailable = false;
+                    $isAvailable = false;
                     $reason = $unavailableDates[$date];
                 }
                 // Pre-fill all stations as free
@@ -277,6 +278,22 @@ class SpotBookingController extends BaseController
 
             // --- 6. Update daily status (free / partial / fully / blocked) ---
             foreach ($calendar as $date => &$dayData) {
+                // If the studio is unavailable for this date (weekly off/holiday or explicit block),
+                // force the day to be blocked regardless of per-station statuses.
+                if (! $dayData['studio_availability']) {
+                    foreach ($dayData['stations'] as $idx => $station) {
+                        $dayData['stations'][$idx]['status'] = 'blocked';
+                        if (empty($dayData['stations'][$idx]['reason'])) {
+                            $dayData['stations'][$idx]['reason'] = $dayData['reason'];
+                        }
+                    }
+                    $dayData['stations_available'] = 0;
+                    $dayData['stations_unavailable'] = $dayData['total'];
+                    $dayData['status'] = 'blocked';
+                    $dayData['booked'] = $dayData['total'];
+                    continue;
+                }
+
                 // count how many stations are not free (booked or blocked)
                 $statuses = collect($dayData['stations'])->pluck('status');
                 $unavailableCount = $statuses->filter(fn ($s) => $s !== 'free')->count();
@@ -366,11 +383,12 @@ class SpotBookingController extends BaseController
             $date = sprintf('%04d-%02d-%02d', $year, $month, $day);
             $dayName = strtolower(Carbon::parse($date)->format('l'));
 
-            $isAvailable = $weeklyAvailability[$dayName] ?? true;
+            $isAvailable = (bool) ($weeklyAvailability[$dayName] ?? true);
             $reason = $isAvailable ? 'Working day' : 'Holiday';
 
+            // Override weekly availability if studio has an explicit unavailable date
             if (isset($unavailableDates[$date])) {
-                $studioAvailable = false;
+                $isAvailable = false;
                 $reason = $unavailableDates[$date];
             }
             // Pre-fill all stations as free
@@ -474,6 +492,22 @@ class SpotBookingController extends BaseController
 
         // --- 6. Update daily status (free / partial / fully / blocked) ---
         foreach ($calendar as $date => &$dayData) {
+            // If the studio is unavailable for this date (weekly off/holiday or explicit block),
+            // force the day to be blocked regardless of per-station statuses.
+            if (! $dayData['studio_availability']) {
+                foreach ($dayData['stations'] as $idx => $station) {
+                    $dayData['stations'][$idx]['status'] = 'blocked';
+                    if (empty($dayData['stations'][$idx]['reason'])) {
+                        $dayData['stations'][$idx]['reason'] = $dayData['reason'];
+                    }
+                }
+                $dayData['stations_available'] = 0;
+                $dayData['stations_unavailable'] = $dayData['total'];
+                $dayData['status'] = 'blocked';
+                $dayData['booked'] = $dayData['total'];
+                continue;
+            }
+
             // count how many stations are not free (booked or blocked)
             $statuses = collect($dayData['stations'])->pluck('status');
             $unavailableCount = $statuses->filter(fn ($s) => $s !== 'free')->count();


### PR DESCRIPTION
Ensure `studio_availability` is `false` and days are marked as blocked for dates explicitly set as unavailable in `StudioUnavailableDate`.

Previously, `StudioUnavailableDate` entries would set a `reason` but did not explicitly override the `studio_availability` flag, which could remain `true` based on weekly availability. This led to incorrect `studio_availability` status for explicitly blocked dates. This PR corrects this by forcing `studio_availability` to `false` and marking the entire day as 'blocked' when a specific date is listed as unavailable.

---
<a href="https://cursor.com/background-agent?bcId=bc-e07022e1-f7e7-4563-a77f-59a41a44d180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e07022e1-f7e7-4563-a77f-59a41a44d180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

